### PR TITLE
Redact arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ class Redactyl {
   }
 
   isObject(property) {
-    return (typeof property) === 'object' || Array.isArray(property);
+    return (typeof property) === 'object' && !Array.isArray(property);
   }
 
   setText(text) {
@@ -38,7 +38,7 @@ class Redactyl {
   redact(json) {
     let isObject = this.isObject(json);
 
-    if (!isObject) {
+    if (!isObject && !Array.isArray(json)) {
       throw new TypeError('A valid JSON object must be specified');
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,9 +55,7 @@ class Redactyl {
             redacted[prop][index] = this.redact(value);
           }
         });
-      }
-
-      if (this.isObject(redacted[prop])) {
+      } else if (this.isObject(redacted[prop])) {
         redacted[prop] = this.redact(redacted[prop]);
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ class Redactyl {
   }
 
   isObject(property) {
-    return (typeof property) === 'object' && !Array.isArray(property);
+    return (typeof property) === 'object' || Array.isArray(property);
   }
 
   setText(text) {

--- a/test/redactyl.spec.js
+++ b/test/redactyl.spec.js
@@ -154,4 +154,34 @@ describe('Redactyl test suite', function () {
       expect(redacted.obj[prop]).to.equal(DEFAULT_TEXT);
     }
   });
+
+  it('Should redact array with objects', async function () {
+    const properties = [ 'apiKey', 'password', 'phone' ];
+    const redactyl = new Redactyl({ 'properties': properties });
+    sinon.spy(redactyl, 'redact');
+
+    const json = [
+      {
+        'apiKey': 'a1b2c3',
+        'password': 'P@$$w0rd',
+        'phone': 1234567890
+      },
+      {
+        'apiKey': 'a1b2c3',
+        'password': 'P@$$w0rd',
+        'phone': 1234567890
+      }
+    ];
+
+    const redacted = redactyl.redact(json);
+
+    expect(redactyl.redact.callCount).to.equal(3);
+    expect(Array.isArray(redacted)).to.equal(true);
+    expect(redacted.length).to.equal(2);
+    redacted.forEach((item) => {
+      for (const prop in item) {
+        expect(item[prop]).to.equal(DEFAULT_TEXT);
+      }
+    })
+  })
 });

--- a/test/redactyl.spec.js
+++ b/test/redactyl.spec.js
@@ -126,7 +126,7 @@ describe('Redactyl test suite', function () {
 
     let redacted = redactyl.redact(json);
 
-    expect(redactyl.redact.callCount).to.equal(4);
+    expect(redactyl.redact.calledTwice).to.equal(true);
     expect(typeof redacted).to.equal('object');
     for (let prop in redacted.arr[0]) {
       expect(redacted.arr[0][prop]).to.equal(DEFAULT_TEXT);

--- a/test/redactyl.spec.js
+++ b/test/redactyl.spec.js
@@ -126,7 +126,7 @@ describe('Redactyl test suite', function () {
 
     let redacted = redactyl.redact(json);
 
-    expect(redactyl.redact.calledTwice).to.equal(true);
+    expect(redactyl.redact.callCount).to.equal(4);
     expect(typeof redacted).to.equal('object');
     for (let prop in redacted.arr[0]) {
       expect(redacted.arr[0][prop]).to.equal(DEFAULT_TEXT);


### PR DESCRIPTION
Given an array of objects like this

```
[
  { password: 'ollionkauniskissa', username: 'olli' }
]
```

`redactyl.js` throws an error.

This PR changes the entry check to pass arrays too, and changes the two `if`s to `if ... else if`. Existing tests pass and so does the new one.