### PR TITLE
Add TypeScript types for the module

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/rcjpisani/redactyl.js/issues"
   },
   "homepage": "https://github.com/rcjpisani/redactyl.js#readme",
+  "types": "./src/index.d.ts",
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^5.13.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for redactyl.js 1.2
+// Project: https://github.com/rcjpisani/redactyl.js
+
+declare namespace Redactyl {
+  interface Options {
+    /**
+     * An array of property names that should be redacted.
+     */
+    properties: string[];
+
+    /**
+     * Custom text to replace the redacted properties with. Default: [REDACTED]
+     */
+    text?: string;
+  }
+}
+
+declare class Redactyl {
+  constructor(opts: Redactyl.Options);
+
+  /**
+   * Traverse through the specified JSON and replace all properties that match
+   * the property names set through the constructor options object, or the
+   * setText function
+   * .
+   * @param input
+   */
+  redact<T extends object[]|object = any>(input: T): T;
+
+  /**
+   * Set the text to replace the redacted properties with. Default: [REDACTED]
+   *
+   * @param text Text to replace the redacted properties with.
+   */
+  setText(text: string): Redactyl;
+
+  /**
+   * Add the names of properties that should be redacted.
+   *
+   * @param properties Additional names of properties
+   */
+  addProperties(properties: string[]): Redactyl;
+}
+
+export = Redactyl;


### PR DESCRIPTION
Add TypeScript typedef for the module.

```typescript
import * as Redactyl from 'redactyl.js';

const redactyl: Redactyl = new Redactyl({
  properties: [ 'ssn' ]
});

interface Data {
  fullName: string;
  ssn: string;
}

const redacted: Data = redactyl
  .setText('[ XXXXXXX ]')
  .redact<Data>({
    fullName: 'John Doe',
    ssn: '2839274TS84' 
  });

console.log(redacted);
```